### PR TITLE
Update basic.md

### DIFF
--- a/docs/falcon-client/analytics.md
+++ b/docs/falcon-client/analytics.md
@@ -1,0 +1,52 @@
+---
+title: Analytics
+---
+
+## Google Analytics
+
+To add Google Analytics to your Falcon application you need to configure it in your `client/config/default.json`:
+
+```json
+{
+  "googleAnalytics": {
+    "__typename": "ConfigGoogleAnalytics",
+    "trackerID": "<Your Google Analytics Code>"
+  }
+}
+```
+
+Then you need to add the following code to your `App.js`:
+
+Then you need to add the following code to your `App.js`:
+
+```jsx
+import withPageview from "@deity/falcon-client/src/components/withPageview";
+
+const App = () => (
+  ...
+);
+
+export default withPageview(App);
+```
+
+That's it! No further configuration necessary in Falcon or Google Analytics.
+
+## Google Tag Manager
+
+[See more](https://marketingplatform.google.com/about/tag-manager/)
+
+### Configuration
+
+you can configure Google Tag Manager via `config` property in `config/default.json`.
+
+`googleTagManager: object`
+
+- `id: string`: (default `null`) Google Tag Manager ID
+
+```json
+{
+  "googleTagManager": {
+    "id": "id"
+  }
+}
+```

--- a/docs/falcon-client/analytics.md
+++ b/docs/falcon-client/analytics.md
@@ -45,6 +45,7 @@ you can configure Google Tag Manager via `config` property in `config/default.js
 ```json
 {
   "googleTagManager": {
+    "__typename": "ConfigGoogleTagManager",
     "id": "id"
   }
 }

--- a/docs/falcon-client/analytics.md
+++ b/docs/falcon-client/analytics.md
@@ -15,7 +15,6 @@ To add Google Analytics to your Falcon application you need to configure it in y
 }
 ```
 
-
 Then you need to add the following code to your `App.js`:
 
 ```jsx
@@ -29,6 +28,36 @@ export default withPageview(App);
 ```
 
 That's it! No further configuration necessary in Falcon or Google Analytics.
+
+### Advanced Google Analytics usage
+
+Falcon exposes a `withAnalytics` higher-order component in order to send custom analytics data to Google Analytics. This component provides the `ga` property for your component, which can be used to send custom events:
+
+```jsx
+import React from "react";
+import withAnalytics from "@deity/falcon-client/src/components/withAnalytics";
+
+class Custom extends React.Component {
+  handleClick(e) {
+    // "ga" provided by "withAnalytics" HOC
+    const { ga } = this.props;
+    ga.send("event", {
+      ec: "My event category",
+      ea: "My event action",
+      el: "My event label",
+      ev: "My event value"
+    });
+  }
+
+  render() {
+    return <button onClick={() => this.handleClick()}>Click me!</button>;
+  }
+}
+
+export default withAnalytics(Custom);
+```
+
+Please refer to a complete list of hit types [here](https://github.com/lukeed/ganalytics/#gasendtype-params).
 
 ## Google Tag Manager
 
@@ -50,3 +79,5 @@ you can configure Google Tag Manager via `config` property in `config/default.js
   }
 }
 ```
+
+This is all you need to do to add Google Tag Manager to your Falcon project. Falcon-Client will handle the rest automatically.

--- a/docs/falcon-client/basics.md
+++ b/docs/falcon-client/basics.md
@@ -154,7 +154,42 @@ For more examples see [this](https://github.com/nfl/react-helmet#reference-guide
 
 ### Google Analytics
 
-[TODO]
+To add Google Analytics to your Falcon application you need to configure it in your `client/config/default.json`:
+
+```json
+{
+  "__typename": "ClientConfig",
+  "appName": "deity-website",
+  "port": 3000,
+  "serverSideRendering": true,
+  "graphqlUrl": "http://localhost:4000/graphql",
+  "apolloClient": {
+    "__typename": "ApolloClientConfig",
+    "httpLink": {
+      "__typename": "ApolloClientConfigHttp",
+      "uri": "/graphql"
+    }
+  },
+  "googleAnalytics": {
+    "__typename": "ConfigGoogleAnalytics",
+    "trackerID": "<Your Google Analytics Code>"
+  }
+}
+```
+
+Then you need to add the following code to your `App.js`:
+
+```jsx
+import withPageview from "@deity/falcon-client/src/components/withPageview";
+
+const App = () => (
+  ...
+);
+
+export default withPageview(App);
+```
+
+That's it! No further configuration necessary in Falcon or Google Analytics.
 
 ### Google Tag Manager
 
@@ -195,9 +230,8 @@ However, css modules convention is also supported [see the details](https://gith
 `falcon-client` exposes `FalconClientMock` component which allows you to setup application context inside unit test environment.
 `FalconClientMock` can receive props for mock version of React context provider components used by `falcon-client` internally:
 
-- `apollo: object` - props for `MockProvider` component from `react-apollo`
-- `router: object` props for `MemoryRouter` component from `react-router-dom`
-- `asyncComponent: object` - props for `AsyncComponentProvider` component from `react-async-component`
+- `apollo: object` - props for [`MockedProvider`](https://www.apollographql.com/docs/react/development-testing/testing/#mockedprovider) component from `react-apollo`.
+- `router: object` props for [`MemoryRouter`](https://reacttraining.com/react-router/web/api/MemoryRouter) component from `react-router-dom`
 - `i18next: object` - props for `I18nextProvider` component from `react-i18next`
 
 example unit test with `FalconClientMock` :

--- a/docs/falcon-client/basics.md
+++ b/docs/falcon-client/basics.md
@@ -132,7 +132,7 @@ To make your shop SEO-friendly, following mechanisms are involved out of the box
 
 ### Server Side Rendering
 
-SSR take place when a website is first opened. All operations are carried out on the server and the browser gets an HTML with all information, same as with typical websites with static pages which search engines can index. After JavaScript is loaded the web turns into a "single page app" and works respectively.
+SSR take place when a website is tfirst opened. All operations are carried out on the server and the browser gets an HTML with all information, same as with typical websites with static pages which search engines can index. After JavaScript is loaded the web turns into a "single page app" and works respectively.
 
 ### Dynamic meta description
 
@@ -178,6 +178,8 @@ export default withPageview(App);
 
 That's it! No further configuration necessary in Falcon or Google Analytics.
 
+[Read more](falcon-client/analytics.md#advanced-google-analytics-usage) about advanced Google Analytics usage.
+
 ### Google Tag Manager
 
 [See more](https://marketingplatform.google.com/about/tag-manager/)
@@ -197,6 +199,8 @@ you can configure Google Tag Manager via `config` property in `config/default.js
   }
 }
 ```
+
+This is all you need to do to add Google Tag Manager to your Falcon project. Falcon-Client will handle the rest automatically.
 
 ## Development
 

--- a/docs/falcon-client/basics.md
+++ b/docs/falcon-client/basics.md
@@ -23,7 +23,6 @@ yarn add @deity/falcon-client
 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
-
 ## Quick Start
 
 Use the project generator:
@@ -158,18 +157,6 @@ To add Google Analytics to your Falcon application you need to configure it in y
 
 ```json
 {
-  "__typename": "ClientConfig",
-  "appName": "deity-website",
-  "port": 3000,
-  "serverSideRendering": true,
-  "graphqlUrl": "http://localhost:4000/graphql",
-  "apolloClient": {
-    "__typename": "ApolloClientConfig",
-    "httpLink": {
-      "__typename": "ApolloClientConfigHttp",
-      "uri": "/graphql"
-    }
-  },
   "googleAnalytics": {
     "__typename": "ConfigGoogleAnalytics",
     "trackerID": "<Your Google Analytics Code>"
@@ -237,17 +224,17 @@ However, css modules convention is also supported [see the details](https://gith
 example unit test with `FalconClientMock` :
 
 ```jsx
-import { FalconClientMock } from '@deity/falcon-client/test-utils';
+import { FalconClientMock } from "@deity/falcon-client/test-utils";
 
-describe('<Component />', () => {
-  test('renders without exploding', () => {
+describe("<Component />", () => {
+  test("renders without exploding", () => {
     ReactDOM.render(
       <FalconClientMock>
         {
           // your <Component />
         }
       </FalconClientMock>,
-      document.createElement('div')
+      document.createElement("div")
     );
   });
 });

--- a/docs/falcon-client/configurations.md
+++ b/docs/falcon-client/configurations.md
@@ -11,7 +11,7 @@ Application needs to have `index.js` file, and the following optional configurat
 This is an application entry point which needs to export valid React element `React.ReactElement<any>` as default:
 
 ```js
-import App from './src/App';
+import App from "./src/App";
 
 export default App;
 ```
@@ -19,7 +19,7 @@ export default App;
 In order to use your custom Apollo Schema you need to export it via `clientApolloSchema`:
 
 ```js
-import clientApolloSchema from './src/clientState';
+import clientApolloSchema from "./src/clientState";
 
 export { clientApolloSchema };
 ```
@@ -31,9 +31,9 @@ For more information see [this](falcon-client/state-management.md)
 This is an optional runtime configuration file.
 
 ```js
-const config = require('config');
+const config = require("config");
 
-export default async() => ({
+export default async () => ({
   config: { ...config },
   onServerCreated: server => {},
   onServerInitialized: server => {},
@@ -50,9 +50,9 @@ This is configuration object used to setup `@deity/falcon-client`
 - `port: number` - (default: `3000`) port number that client should be running on
 - `logLevel: string` - (default: `'error'`) [@deity/falcon-logger](https://github.com/deity-io/falcon/tree/master/packages/falcon-logger) logger level
 - `serverSideRendering: boolean` - (default `true`) switch to control whether the [SSR](/docs/falcon-client/basics#server-side-rendering) is enabled
-- `googleTagManager: object` - Google Tag Manager configuration, [see the details](/docs/falcon-client/basics#google-tag-manager)
+- `googleTagManager: object` - Google Tag Manager configuration, [see the details](/docs/falcon-client/analytics#google-tag-manager)
 - `googleAnalytics: object`
-  - `trackerID` - Google Analytics tracking code
+  - `trackerID` - Google Analytics tracking code [see the details](/docs/falcon-client/analytics#google-analytics)
 - `i18n: object` - internationalization configuration, [see the details](/docs/falcon-client/internationalization)
 - `menus: object` - menus configuration [TODO]
 - `graphqlUrl: string` - (default: `http://localhost:4000/graphql`) the real GraphQL URL to be proxied by Falcon-Client under `apolloClient.httpLink.uri` path. If you set this key with a falsy value - no proxying will be performed
@@ -144,7 +144,7 @@ For example, bellow configuration expose environment variable named `SECRET_CODE
 
 ```js
 module.exports = {
-  envToBuildIn: ['SECRET_CODE']
+  envToBuildIn: ["SECRET_CODE"]
 };
 ```
 
@@ -156,7 +156,7 @@ To use Falcon Client (or Razzle) plugin, you need to install it in your project,
 
 ```js
 module.exports = {
-  plugins: ['plugin-name']
+  plugins: ["plugin-name"]
 };
 ```
 
@@ -171,10 +171,10 @@ Plugins are simply functions that modify and return Falcon Client's webpack conf
 module.exports = function myFalconClientPlugin(config, env, webpack) {
   const { target, dev } = env;
 
-  if (target === 'web') {
+  if (target === "web") {
     // client only
   }
-  if (target === 'server') {
+  if (target === "server") {
     // server only
   }
   if (dev) {
@@ -237,7 +237,7 @@ Falcon Client gives you Ecma Script 6 compiled via Babel 7. However, if you want
 ```json
 {
   "presets": [
-    "@deity/babel-preset-falcon-client", // needed
+    "@deity/babel-preset-falcon-client" // needed
   ],
   "plugins": [
     // additional plugins
@@ -268,7 +268,6 @@ build/*
 coverage/*
 ```
 
-
 ### Jest
 
 Falcon Client comes with configured [Jest](https://jestjs.io/) test runner. However it is possible to override it by adding `jest` node into `package.json`. Below example configures `setupTestFrameworkScriptFile` file:
@@ -276,8 +275,8 @@ Falcon Client comes with configured [Jest](https://jestjs.io/) test runner. Howe
 ```json
 // package.json
 {
- "jest": {
-   "setupTestFrameworkScriptFile": "./setupTests.js"
- }
+  "jest": {
+    "setupTestFrameworkScriptFile": "./setupTests.js"
+  }
 }
 ```

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -12,6 +12,7 @@
       "falcon-client/configurations",
       "falcon-client/code-splitting",
       "falcon-client/state-management",
+      "falcon-client/analytics",
       "falcon-client/internationalization",
       "falcon-client/falcon-ui",
       "falcon-client/search-and-filtering"


### PR DESCRIPTION
What I did:
- Add Google Analytics information
- Removed `react-async-component` information from `FalconClientMock` since it is no longer used

Also, I need some help with the info about the `i18next` prop for `FalconClientMock`. 
We are using `i18next` instead of `react-i18next` and I am getting an error in the [`I18nProvderProps`](https://github.com/deity-io/falcon/blob/dev/packages/falcon-i18n/src/I18nProvider.tsx#L6) saying Namespace `'"/node_modules/i18next/index".export=' has no exported member 'i18n'.` I am also getting this error in the [context](https://github.com/deity-io/falcon/blob/dev/packages/falcon-i18n/src/context.tsx#L19). I would like to add a link here to all the available props specified in the `i18next` documentation.

I also need help documenting what exactly this [`<DynamicRoute />`](https://github.com/deity-io/falcon/blob/dev/examples/shop-with-blog/client/src/pages/DynamicRoute.js) component does 
and how someone could use the original [`DynamicRoute`](https://github.com/deity-io/falcon/blob/dev/packages/falcon-front-kit/src/DynamicRoute/DynamicRoute.tsx) 

It would also be great if you could tell me what the [`falcon-front-kit`](https://github.com/deity-io/falcon/tree/dev/packages/falcon-front-kit) package is for. I'd like to start adding a README to every package explaining its purpose, how it works and how it is structured, or at least a link to the documentation where this information is available. The goal here is to make contributing and writing docs easier.

Preview: https://deploy-preview-69--falcon-docs.netlify.com/docs/falcon-client/basics